### PR TITLE
restore nested md highlighting code

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,9 @@
           "light": "d2-icon-small.png",
           "dark": "d2-icon-small.png"
         }
+      },
+      {
+        "id": "markdown.d2"
       }
     ],
     "grammars": [
@@ -51,6 +54,11 @@
           "meta.embedded.block.markdown": "markdown",
           "meta.embedded.block.latex": "latex"
         }
+      },
+      {
+        "language": "markdown.d2",
+        "scopeName": "text.html.markdown.d2",
+        "path": "./syntaxes/markdown.tmLanguage.json"
       }
     ],
     "markdown.markdownItPlugins": true,


### PR DESCRIPTION
## Summary

Restore code for highlighting markdown syntax in d2.

## Details
- was accidentally removed [here](https://github.com/terrastruct/d2-vscode/pull/21/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L43-L57)

### before

![Screen Shot 2023-01-19 at 2 58 43 PM](https://user-images.githubusercontent.com/85081687/213581236-f5da03a1-69ce-408e-a034-fd0c03c5cdb0.png)

### after

![Screen Shot 2023-01-19 at 2 58 54 PM](https://user-images.githubusercontent.com/85081687/213581224-c89e63f6-a841-4930-8f74-5f1123329014.png)
