### PR TITLE
Add configuration to specifiy abolute path to d2 executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You can install using the extension sidebar or by going to the [Visual Studio Ma
 To package and install the extension locally, run:
 
 ```sh
-npm install -g vsce
+npm install -g @vscode/vsce
 npm run dev
 ```
 
@@ -64,7 +64,7 @@ debug VS Code with the updated extension.
 
 ### Generating tmLanguage.json
 
-To regenerate `d2.tmLanguage.json` after updating `d2.tmLanguage.yaml`:
+To regenerate `d2.tmLanguage.json` after updating `d2.tmLanguage.yaml`, use [yq](https://github.com/mikefarah/yq/#install):
 
 ```sh
 brew install yq
@@ -89,7 +89,7 @@ Highly recommend the following keybind for inspecting the textmate scopes under 
 See https://code.visualstudio.com/docs/editor/extension-marketplace#_install-from-a-vsix
 
 ```sh
-npm install -g vsce
+npm install -g @vscode/vsce
 npm run pkg
 # To install:
 # code --install-extension d2.vsix

--- a/package.json
+++ b/package.json
@@ -148,6 +148,11 @@
           "type": "boolean",
           "default": "false",
           "description": "Use sketch rendering in preview."
+        },
+        "D2.execPath": {
+          "type": "string",
+          "default": "d2",
+          "description": "Path to d2 executable if not on current PATH"
         }
       }
     },

--- a/src/docToPreviewGenerator.ts
+++ b/src/docToPreviewGenerator.ts
@@ -105,8 +105,9 @@ export class DocToPreviewGenerator {
       const theme: string = ws.get("previewTheme", "default");
       const sketch: boolean = ws.get("previewSketch", false);
       const themeNumber: number = NameToThemeNumber(theme);
+      const d2Path: string = ws.get("execPath", "d2");
 
-      const proc = spawnSync("d2", [
+      const proc = spawnSync(d2Path, [
         `--layout=${layout}`,
         `--theme=${themeNumber}`,
         `--sketch=${sketch}`,

--- a/src/documentFormatter.ts
+++ b/src/documentFormatter.ts
@@ -4,7 +4,7 @@ import * as path from "path";
 import * as temp from "temp";
 import { Range, TextEditor } from "vscode";
 
-import { outputChannel } from "./extension";
+import { outputChannel, ws } from "./extension";
 
 /**
  * DocumentFormatter - Takes the current TextEditor, runs the
@@ -20,7 +20,8 @@ export class DocumentFormatter {
       writeFileSync(this.inFile, fileText);
 
       try {
-        const proc = spawnSync("d2", ["fmt", this.inFile]);
+        const d2Path: string = ws.get("execPath", "d2");
+        const proc = spawnSync(d2Path, ["fmt", this.inFile]);
 
         let errorString = "";
         if (proc.status !== 0) {


### PR DESCRIPTION
I couldn't figure out how to get VSCode to get `d2` on my path on linux (arch btw) so I added a configuration to override with the absolute path.  It defaults to looking on the path. 

Also made some minor updates to the README.  

May help folks experiencing https://github.com/terrastruct/d2-vscode/issues/33 as well. 