### PR TITLE
only trigger preview update if there was a content change

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -61,7 +61,7 @@ export function activate(context: ExtensionContext): any {
 
   context.subscriptions.push(
     workspace.onDidChangeTextDocument((e: TextDocumentChangeEvent) => {
-      if (e.document.languageId === d2Ext) {
+      if (e.document.languageId === d2Ext && e.contentChanges.length > 0) {
         const autoUp = ws.get("autoUpdate", false);
 
         if (autoUp) {


### PR DESCRIPTION
## Summary

Noticed there would sometimes be document change events that didn't have any content changes.

## Details
- avoid extra compiles

### seemed to be updating twice for each change

```
[20:09:16] - Preview for dia.d2 updated. <-changed file
[20:09:18] - Preview for dia.d2 updated.
[20:09:33] - Preview for dia.d2 updated. <- changed file
[20:09:34] - Preview for dia.d2 updated.
```

### some events had no content changes

![Screen Shot 2023-02-22 at 8 06 28 PM](https://user-images.githubusercontent.com/85081687/220819748-a942c798-8605-4a2b-a15c-274fe6a127f3.png)
