### PR TITLE
Add ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: ci
+on: [push, pull_request]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets._GITHUB_TOKEN }}
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16.x'
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - run: COLOR=1 ./make.sh
+        timeout-minutes: 30
+        env:
+          GITHUB_TOKEN: ${{ secrets._GITHUB_TOKEN }}
+  nofixups:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: git submodule update --init
+      - run: COLOR=1 ./ci/sub/bin/nofixups.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets._GITHUB_TOKEN }}

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1,0 +1,26 @@
+name: daily
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '42 0 * * *' # daily at 00:42
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets._GITHUB_TOKEN }}
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16.x'
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - run: COLOR=1 CI_FORCE=1 ./make.sh
+        timeout-minutes: 30
+        env:
+          GITHUB_TOKEN: ${{ secrets._GITHUB_TOKEN }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ci/sub"]
+	path = ci/sub
+	url = https://github.com/terrastruct/ci

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
   <br />
 </div>
 
+[![ci](https://github.com/terrastruct/d2-vscode/actions/workflows/ci.yml/badge.svg)](https://github.com/terrastruct/d2-vscode/actions/workflows/ci.yml)
+[![daily](https://github.com/terrastruct/d2-vscode/actions/workflows/daily.yml/badge.svg)](https://github.com/terrastruct/d2-vscode/actions/workflows/daily.yml)
+[![license](https://img.shields.io/github/license/terrastruct/d2-vscode?color=9cf)](./LICENSE)
+
 # VSCode extension for [D2](https://d2lang.com) files.
 
 _Note: Requires D2 to be installed on your machine. See
@@ -59,7 +63,26 @@ can also run the following on macOS:
 osascript -e 'quit app "Visual Studio Code"'; yarn dev && code ~/d2-testing
 ```
 
-To package for marketplace:
+### CI
+
+CI relies on Terrastruct's shared [CI submodule](https://github.com/terrastruct/ci).
+
+To run all CI: `./make.sh`.
+
+To run individual jobs:
+
+- Format: `./make.sh fmt`
+- Lint: `./make.sh lint`
+- Build: `./make.sh build`
+
+Jobs only run on changed files. To force it to run on all files, add `CI_FORCE=1`. This is
+what daily job does.
+
+```
+CI_FORCE=1 ./make.sh fmt
+```
+
+### Packaging
 
 ```sh
 vsce package

--- a/make.sh
+++ b/make.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -eu
+if [ \( -z "${CI_MAKE_ROOT-}" -a -n "${CI-}" \) -o ! -e "$(dirname "$0")/ci/sub/.git" ]; then
+  set -x
+  git submodule update --init
+  set +x
+fi
+. "$(dirname "$0")/ci/sub/lib.sh"
+PATH="$(cd -- "$(dirname "$0")" && pwd)/ci/sub/bin:$PATH"
+cd "$(dirname "$0")"
+
+lint() {
+  sh_c hide xargsd "'\.\(ts\|tsx\|scss\|css\)$'" npx eslint@8.36.0
+}
+
+ensure_changed_files
+job_parseflags "$@"
+runjob fmt ./ci/sub/bin/fmt.sh &
+if <"$CHANGED_FILES" grep -q '\.\(ts\|tsx\|scss\|css\)$'; then
+  runjob lint &
+fi
+runjob build 'yarn package' &
+ci_waitjobs

--- a/package.json
+++ b/package.json
@@ -284,7 +284,6 @@
     "compile": "webpack",
     "watch": "webpack --watch",
     "package": "webpack --mode production --devtool hidden-source-map",
-    "lint": "eslint src --ext ts",
     "dev": "code --uninstall-extension terrastruct.d2; yarn gen && yarn pkg && code --install-extension d2.vsix",
     "gen": "yq --output-format json syntaxes/d2.tmLanguage.yaml > syntaxes/d2.tmLanguage.json",
     "pkg": "vsce package --out d2.vsix"

--- a/pages/previewPage.html
+++ b/pages/previewPage.html
@@ -104,9 +104,7 @@
         svg.style.width = "100%";
         setZoomText(false);
 
-        zoomLevel = roundToZoomLevel(
-          (svg.clientHeight / svg.height.baseVal.value) * 100
-        );
+        zoomLevel = roundToZoomLevel((svg.clientHeight / svg.height.baseVal.value) * 100);
 
         fitMode = true;
       }

--- a/src/browserWindow.ts
+++ b/src/browserWindow.ts
@@ -30,16 +30,11 @@ export class BrowserWindow {
         enableFindWidget: true,
         enableScripts: true,
         retainContextWhenHidden: true,
-        localResourceRoots: [
-          Uri.file(path.join(extContext.extensionPath, "pages")),
-        ],
+        localResourceRoots: [Uri.file(path.join(extContext.extensionPath, "pages"))],
       }
     );
 
-    const onDiskPath = path.join(
-      extContext.extensionPath,
-      "pages/previewPage.html"
-    );
+    const onDiskPath = path.join(extContext.extensionPath, "pages/previewPage.html");
     const data: string = readFileSync(onDiskPath, "utf-8");
 
     this.webViewPanel.webview.html = data.toString();

--- a/src/docToPreviewGenerator.ts
+++ b/src/docToPreviewGenerator.ts
@@ -88,9 +88,7 @@ export class DocToPreviewGenerator {
 
         let msg = "";
         arr.forEach((s, i) => {
-          msg += `<text fill="#757575" x="15" y="${
-            i * 12 + 100
-          }">${s}</text>\n`;
+          msg += `<text fill="#757575" x="15" y="${i * 12 + 100}">${s}</text>\n`;
         });
 
         trkObj.outputDoc.setSvg(`<svg>${msg}</svg>`);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,8 +33,7 @@ const d2Lang = "d2";
 const previewGenerator: DocToPreviewGenerator = new DocToPreviewGenerator();
 
 export const d2ConfigSection = "D2";
-export let ws: WorkspaceConfiguration =
-  workspace.getConfiguration(d2ConfigSection);
+export let ws: WorkspaceConfiguration = workspace.getConfiguration(d2ConfigSection);
 export const outputChannel: D2OutputChannel = new D2OutputChannel();
 export const taskRunner: TaskRunner = new TaskRunner();
 export let extContext: ExtensionContext;
@@ -150,18 +149,13 @@ export function activate(context: ExtensionContext): any {
             return;
           }
 
-          const svgFilename =
-            filePath.substr(0, filePath.lastIndexOf(".")) + ".svg";
+          const svgFilename = filePath.substr(0, filePath.lastIndexOf(".")) + ".svg";
           const encoder = new TextEncoder();
           const encodedText = encoder.encode(svgText);
 
-          workspace.fs
-            .writeFile(Uri.file(svgFilename), encodedText)
-            .then(() => {
-              outputChannel.appendInfo(
-                `File ${filePath} converted to ${svgFilename}`
-              );
-            });
+          workspace.fs.writeFile(Uri.file(svgFilename), encodedText).then(() => {
+            outputChannel.appendInfo(`File ${filePath} converted to ${svgFilename}`);
+          });
         });
       });
     })

--- a/src/layoutPicker.ts
+++ b/src/layoutPicker.ts
@@ -19,10 +19,7 @@ class LayoutItem implements QuickPickItem {
  */
 const layouts: QuickPickItem[] = [
   new LayoutItem("dagre", "The directed graph layout library Dagre"),
-  new LayoutItem(
-    "elk",
-    "Eclipse Layout Kernel (ELK) with the Layered algorithm"
-  ),
+  new LayoutItem("elk", "Eclipse Layout Kernel (ELK) with the Layered algorithm"),
 ];
 
 const layoutTala = new LayoutItem("tala", "Terrastruct's AutoLayout Approach");

--- a/src/taskRunner.ts
+++ b/src/taskRunner.ts
@@ -26,11 +26,7 @@ export type TaskOutput = (text: string, flag?: boolean) => void;
  */
 export class TaskRunner {
   public retVal = "";
-  public genTask(
-    filename: string,
-    text: string,
-    callback: TaskRunnerCallback
-  ): void {
+  public genTask(filename: string, text: string, callback: TaskRunnerCallback): void {
     const pty = new CustomTaskTerminal(filename, text, callback);
     const ce = new CustomExecution(
       (): Promise<CustomTaskTerminal> =>
@@ -96,9 +92,7 @@ class CustomTaskTerminal implements Pseudoterminal {
       (err, flag) => {
         if (flag === true) {
           this.compileErrors += err + "\n";
-          this.writeLine(
-            `[${path.join(this.fileDirectory, this.fileName)}] ${err}`
-          );
+          this.writeLine(`[${path.join(this.fileDirectory, this.fileName)}] ${err}`);
         } else {
           this.writeLine(err);
         }

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -114,9 +114,7 @@ class D2Tasks {
       builder.replace(
         new Range(
           textEditor.document.lineAt(0).range.start,
-          textEditor.document.lineAt(
-            textEditor.document.lineCount - 1
-          ).range.end
+          textEditor.document.lineAt(textEditor.document.lineCount - 1).range.end
         ),
         data
       );


### PR DESCRIPTION
- prevent the back and forths of whether prettier was run
- pin the versions of prettier and eslint so results don't vary machine to machine
- run everything in parallel
- add the requirement for merging that a package must succeed at building
- badges tell us if there's ever a bad merge that broke CI

CI adding all in one commit. regenerating files with new formatter is second commit (we use a different line-width: https://github.com/terrastruct/ci/blob/master/bin/fmt.sh#L39 )

cc @BarryNolte @gavin-ts 