### PR TITLE
disable esModuleInterop

### DIFF
--- a/src/taskRunner.ts
+++ b/src/taskRunner.ts
@@ -1,4 +1,4 @@
-import * as path from "path";
+import path = require("path");
 
 import {
   CustomExecution,

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "commonjs",
     "target": "ES2020",
     "lib": ["ES2020"],
-    "esModuleInterop": true,
+    "esModuleInterop": false,
     "sourceMap": true,
     "rootDir": "../src",
     "strict": true


### PR DESCRIPTION
## Summary

This reverts an unnecessary change that may have caused #74. Not 100% certain but esModuleInterop may be causing imports to use non-absolute paths, which might be the source of the error being encountered.