### PR TITLE
Added option to turn off check for D2 executable on startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -191,6 +191,11 @@
           "type": "string",
           "default": "d2",
           "description": "Path to d2 executable if not on current PATH"
+        },
+        "D2.checkForInstallAtStart": {
+          "type": "boolean",
+          "default": true,
+          "description": "Check for required D2 command line tools on startup."
         }
       }
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -231,7 +231,10 @@ export function activate(context: ExtensionContext): any {
   /**
    * Check that D2 is available up front
    */
-  util.checkForD2Install();
+  const checkForD2 = ws.get("checkForInstallAtStart");
+  if (checkForD2) {
+    util.checkForD2Install();
+  }
 
   // Return our markdown renderer
   return {


### PR DESCRIPTION
Fixes #105 

Adding a setting to check for installation or not was the best solution.