### PR TITLE
Fix for d2 syntax coloring in markdown files

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,9 @@
       },
       {
         "id": "markdown.d2"
+      },
+      {
+        "id": "d2-markdown-injection"
       }
     ],
     "grammars": [
@@ -84,6 +87,17 @@
         "language": "markdown.d2",
         "scopeName": "text.html.markdown.d2",
         "path": "./syntaxes/markdown.tmLanguage.json"
+      },
+      {
+        "language": "d2-markdown-injection",
+        "scopeName": "markdown.d2.codeblock",
+        "path": "./syntaxes/d2-markdown-injection.json",
+        "injectTo": [
+          "text.html.markdown"
+        ],
+        "embeddedLanguages": {
+          "meta.embedded.block.d2": "d2"
+        }
       }
     ],
     "markdown.markdownItPlugins": true,

--- a/syntaxes/d2-markdown-injection.json
+++ b/syntaxes/d2-markdown-injection.json
@@ -1,0 +1,45 @@
+{
+    "fileTypes": [],
+    "injectionSelector": "L:text.html.markdown",
+    "patterns": [
+        {
+            "include": "#d2-code-block"
+        }
+    ],
+    "repository": {
+        "d2-code-block": {
+            "begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(d2)(\\s+[^`~]*)?$)",
+            "name": "markup.fenced_code.block.markdown",
+            "end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+            "beginCaptures": {
+                "3": {
+                    "name": "punctuation.definition.markdown"
+                },
+                "4": {
+                    "name": "fenced_code.block.language.markdown"
+                },
+                "5": {
+                    "name": "fenced_code.block.language.attributes.markdown"
+                }
+            },
+            "endCaptures": {
+                "3": {
+                    "name": "punctuation.definition.markdown"
+                }
+            },
+            "patterns": [
+                {
+                    "begin": "(^|\\G)(\\s*)(.*)",
+                    "while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+                    "contentName": "meta.embedded.block.d2",
+                    "patterns": [
+                        {
+                            "include": "source.d2"
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    "scopeName": "markdown.d2.codeblock"
+}


### PR DESCRIPTION
This is the same PR as #120, except all the commits are verified.  I had my master branch in a bad state and it took me a while to figure out how to fix it.