### PR TITLE
Fix "Move to new window" issue and add pan.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 package-lock.json
+.github
+scripts/github

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,225 @@
+# AGENTS.md
+
+This file provides guidance to AI agents working with code in this repository.
+
+## Project Overview
+
+D2-vscode is a VS Code extension for the [D2 diagramming language](https://d2lang.com). It provides syntax highlighting, live preview, formatting, theme/layout selection, and markdown rendering for `.d2` files. The extension shells out to the `d2` CLI binary for compilation and formatting — it does **not** include a D2 compiler.
+
+## Architecture
+
+### Core Design Principles
+
+1. **CLI-dependent**: All compilation and formatting delegates to the external `d2` binary via `spawnSync`. The extension never parses or compiles D2 itself.
+2. **Singleton modules**: Key objects (`previewGenerator`, `outputChannel`, `taskRunner`, `ws`, `d2Tasks`) are exported as module-level singletons from `extension.ts` and `tasks.ts`.
+3. **Document tracking**: Each open `.d2` document gets a `D2P` tracking object that connects it to its preview webview and refresh timer.
+4. **VS Code Tasks API**: Compilation runs as a `CustomExecution` task with a `Pseudoterminal`, enabling the `D2Matcher` problem matcher to surface errors in the Problems panel.
+
+### Directory Structure
+
+```
+d2-vscode/
+├── src/
+│   ├── extension.ts             # Entry point — activate(), registers commands, events, markdown renderer
+│   ├── docToPreviewGenerator.ts # Singleton: tracks D2P (document→preview) map, orchestrates compilation
+│   ├── browserWindow.ts         # WebviewPanel wrapper: renders SVG, handles zoom, link clicks, auxiliary window recovery
+│   ├── taskRunner.ts            # Creates CustomExecution tasks with Pseudoterminal for d2 compilation
+│   ├── tasks.ts                 # D2Tasks: synchronous compile() and format() via spawnSync to d2 CLI
+│   ├── refreshTimer.ts          # Debounce timer for auto-update on keystroke (configurable interval)
+│   ├── outputChannel.ts         # D2OutputChannel: timestamped logging to "D2-Output" channel
+│   ├── layoutPicker.ts          # QuickPick: dagre, elk, tala (tala only if d2plugin-tala on PATH)
+│   ├── themePicker.ts           # QuickPick: 19 themes, NameToThemeNumber() maps name→CLI number
+│   ├── utility.ts               # PATH lookup, d2 install check, openWithDefaultApp (cross-platform)
+│   └── tsconfig.json            # TypeScript config (ES2020, commonjs, strict)
+├── pages/
+│   └── previewPage.html         # Webview HTML: zoom controls, drag-to-pan, SVG rendering, state persistence
+├── syntaxes/
+│   ├── d2.tmLanguage.yaml       # Source of truth for D2 grammar (compiled to JSON via yq)
+│   ├── d2.tmLanguage.json       # Generated — do NOT edit directly, edit the .yaml
+│   ├── d2-markdown-injection.json # Injects D2 syntax into markdown fenced code blocks
+│   └── markdown.tmLanguage.json # D2-flavored markdown for embedded |md blocks
+├── themes/
+│   ├── dark-color-theme.json    # D2 Dark editor theme
+│   └── light-color-theme.json   # D2 Light editor theme
+├── test/                        # Sample .d2 and .md files for manual testing (no automated tests)
+├── language-configuration.json  # Bracket pairs, comments (#, """), indent rules for D2
+├── webpack.config.js            # Bundles src/ → dist/extension.js (ts-loader, commonjs2, node target)
+├── eslint.config.mjs            # ESLint 9 flat config with typescript-eslint + prettier
+├── make.sh                      # CI entry point: fmt, lint, build (uses ci/sub submodule)
+└── package.json                 # Extension manifest: commands, settings, grammars, themes
+```
+
+### Key Data Flow
+
+#### Edit → Preview Flow
+
+```
+User edits .d2 file
+  ↓
+onDidChangeTextDocument fires (extension.ts)
+  ↓
+RefreshTimer resets (debounces keystrokes, default 1500ms)
+  ↓
+Timer fires → DocToPreviewGenerator.generate(doc)
+  ↓
+TaskRunner.genTask() → creates CustomExecution + Pseudoterminal
+  ↓
+D2Tasks.compile() → spawnSync("d2", [...args, "-"], { input: text })
+  ↓
+SVG output → BrowserWindow.setSvg() → caches SVG + postMessage to webview
+  ↓
+Errors → written to Pseudoterminal → D2Matcher problemMatcher → Problems panel
+```
+
+#### Save → Preview Flow (updateOnSave mode)
+
+```
+User saves .d2 file (manual save only, not auto-save)
+  ↓
+onWillSaveTextDocument sets hardSave flag
+  ↓
+onDidSaveTextDocument checks hardSave && updateOnSave setting
+  ↓
+DocToPreviewGenerator.generate(doc)
+```
+
+### Extension Activation & Wiring (extension.ts)
+
+```
+1. Register onDidChangeConfiguration listener (re-generate on setting change)
+2. Register onDidChangeTextDocument (auto-update via RefreshTimer)
+3. Register onWillSaveTextDocument / onDidSaveTextDocument (updateOnSave)
+4. Register onDidOpenTextDocument / onDidCloseTextDocument (D2P tracking)
+5. Register commands: ShowPreviewWindow, CompileToSvg, PickLayout, PickTheme, ToggleSketch
+6. Register DocumentFormattingEditProvider (calls d2Tasks.format)
+7. Track already-open .d2 documents
+8. Check for d2 install (if checkForInstallAtStart enabled)
+9. Return extendMarkdownIt() for markdown code block rendering
+```
+
+## VS Code Extension Specifics
+
+### Activation Event
+
+`onStartupFinished` — the extension activates after VS Code finishes startup, regardless of workspace content.
+
+### Registered Commands (5)
+
+| Command                | Description                                  |
+| ---------------------- | -------------------------------------------- |
+| `D2.ShowPreviewWindow` | Open side-by-side SVG preview (Ctrl+Shift+D) |
+| `D2.CompileToSvg`      | Compile .d2 file to .svg on disk             |
+| `D2.PickTheme`         | QuickPick to choose preview theme            |
+| `D2.PickLayout`        | QuickPick to choose layout engine            |
+| `D2.ToggleSketch`      | Toggle sketch rendering mode                 |
+
+### User Settings (D2.\* namespace)
+
+| Setting                     | Type    | Default     | Purpose                                |
+| --------------------------- | ------- | ----------- | -------------------------------------- |
+| `D2.autoUpdate`             | boolean | `true`      | Auto-update preview on edit            |
+| `D2.updateTimer`            | number  | `1500`      | Debounce interval (ms) for auto-update |
+| `D2.updateOnSave`           | boolean | `false`     | Update preview on manual save          |
+| `D2.previewTheme`           | string  | `"default"` | Theme name for preview rendering       |
+| `D2.previewLayout`          | string  | `"dagre"`   | Layout engine (dagre, elk, tala)       |
+| `D2.previewSketch`          | boolean | `false`     | Sketch rendering mode                  |
+| `D2.execPath`               | string  | `"d2"`      | Path to d2 executable                  |
+| `D2.checkForInstallAtStart` | boolean | `true`      | Check for d2 binary on activation      |
+
+### Problem Matcher
+
+`D2Matcher` parses d2 CLI stderr output into VS Code diagnostics. Pattern: `[filepath] err:ErrorType: line:col: message`.
+
+## Build & Development
+
+### Commands
+
+```sh
+yarn compile         # webpack build (development)
+yarn watch           # webpack watch mode with source maps
+yarn package         # webpack production build (used for publishing)
+yarn dev             # uninstall → gen grammar → package → install locally
+yarn gen             # compile d2.tmLanguage.yaml → d2.tmLanguage.json via yq
+yarn pkg             # vsce package → d2.vsix
+```
+
+### CI (`make.sh`)
+
+Requires the `ci/sub` git submodule. Runs three parallel jobs:
+
+- **fmt**: Formatting check via `ci/sub/bin/fmt.sh`
+- **lint**: ESLint on changed `.ts`/`.tsx`/`.scss`/`.css` files
+- **build**: `yarn package`
+
+Initialize submodule first: `git submodule update --init`
+
+### Local Development Workflow
+
+1. Open this repo in VS Code
+2. Press F5 → launches Extension Development Host with the extension loaded
+3. Edit `.d2` files in the debug instance to test
+4. Press Cmd+R / Ctrl+R in debug instance to reload after changes
+
+### Testing
+
+There are **no automated tests**. The `test/` directory contains sample `.d2` and `.md` files for manual verification of syntax highlighting and nested markdown parsing.
+
+Manual testing checklist:
+
+- Open a `.d2` file, verify syntax highlighting
+- Ctrl+Shift+D → preview opens with rendered SVG
+- Edit `.d2` → preview auto-updates after debounce
+- Verify zoom controls (slider, +/-, fit, Ctrl+scroll)
+- Right-click → "Compile D2 to SVG" → `.svg` file written
+- Pick Theme / Pick Layout from command palette
+- Open a `.md` file with ` ```d2 ` fenced blocks → rendered in markdown preview
+- Toggle sketch mode
+- "Move Editor Group into New Window" → preview survives in auxiliary window
+- Drag to pan the diagram, verify cursor changes to grabbing
+- Pan position persists across zoom changes and state recovery
+
+## Key Dependencies
+
+### Runtime
+
+- **async-mutex**: Mutex for serializing preview generation across multiple documents
+- **markdown-it-container**: Enables D2 rendering inside markdown fenced code blocks
+
+### Dev
+
+- **webpack** + **ts-loader**: Bundles TypeScript → `dist/extension.js`
+- **TypeScript** 5.6, **ESLint** 9 (flat config + prettier)
+- **@vscode/vsce**: Extension packaging
+
+### External
+
+- **d2 CLI binary**: Must be installed on the user's system and on PATH (or configured via `D2.execPath`). The extension is useless without it.
+
+## Module Responsibilities
+
+| Module                     | What it does                                                      | What it does NOT do                             |
+| -------------------------- | ----------------------------------------------------------------- | ----------------------------------------------- |
+| `extension.ts`             | Wires everything, holds singleton refs, returns markdownIt plugin | Contain business logic                          |
+| `docToPreviewGenerator.ts` | Owns D2P tracking map, mutex-sequenced `generateAll()`            | Compile D2 (delegates to taskRunner)            |
+| `browserWindow.ts`         | WebviewPanel lifecycle, SVG caching, auxiliary window recovery, link click handling | Generate SVG                                    |
+| `taskRunner.ts`            | Creates VS Code Task + Pseudoterminal for d2 compilation          | Run d2 directly (delegates to d2Tasks)          |
+| `tasks.ts`                 | `spawnSync` to d2 CLI for compile and format                      | Manage UI or webviews                           |
+| `refreshTimer.ts`          | Debounce keystroke→preview updates                                | Know about D2 or compilation                    |
+| `themePicker.ts`           | Theme name↔number mapping, QuickPick UI                           | Apply themes (config update triggers re-render) |
+| `layoutPicker.ts`          | Layout QuickPick, detects tala plugin on PATH                     | Apply layouts                                   |
+| `utility.ts`               | PATH search, d2 install check, cross-platform file open           | Anything D2-specific                            |
+
+## Common Pitfalls
+
+1. **Don't edit `d2.tmLanguage.json` directly** — it's generated from `d2.tmLanguage.yaml` via `yarn gen` (requires `yq`). Edit the YAML source.
+2. **`spawnSync` blocks the extension host** — `D2Tasks.compile()` and `format()` are synchronous. Large diagrams may cause UI freezes. This is the existing design.
+3. **Singleton coupling** — Most modules import singletons from `extension.ts` (`ws`, `outputChannel`, `taskRunner`, `previewGenerator`). This makes unit testing difficult. Don't add more singleton cross-references without understanding the existing dependency graph.
+4. **WebviewPanel security** — `BrowserWindow` sets `enableScripts: true` and `retainContextWhenHidden: true`. The webview receives SVG directly via `innerHTML`. Any changes to webview content handling must be careful about script injection from malicious `.d2` files.
+5. **Auxiliary window recovery** — When a webview is moved to an auxiliary window ("Move Editor Group into New Window"), VS Code destroys and recreates the iframe. Recovery is handled at two levels: (a) `BrowserWindow.lastSvg` cache re-pushed via `onDidChangeViewState`, and (b) webview-side `vscode.getState()`/`setState()` persistence. Both must stay in sync. If you change SVG delivery, update both paths.
+6. **Drag-to-pan + zoom transform** — `previewPage.html` applies `translate(panX, panY) scale(...)` as a single CSS transform. `applyTransform()` is the single source of truth for the wrapper's `style.transform`. Do not set `wrapper.style.transform` directly — always go through `applyTransform()` to avoid pan/zoom desync.
+7. **Mutex in `DocToPreviewGenerator`** — The `generateAll()` method acquires a mutex per document and releases it via the `onDidEndTask` event. Breaking this flow will deadlock preview generation.
+8. **Theme number mapping** — `NameToThemeNumber()` in `themePicker.ts` must stay in sync with the theme enum in `package.json` settings. If D2 adds new themes, both must be updated.
+9. **Tala detection** — `layoutPicker.ts` dynamically adds/removes the tala option based on PATH detection at picker creation time, not at activation.
+10. **hardSave flag** — The `updateOnSave` flow uses a closure variable `hardSave` to distinguish manual saves from auto-saves. This is fragile — don't refactor save handling without preserving this distinction.
+11. **No tests** — There is no test infrastructure. If adding tests, note that the singleton architecture and `spawnSync` usage make unit testing challenging. Consider extracting pure functions first.
+12. **`previewPage.html` uses `innerHTML`** — The webview sets `wrapper.innerHTML = message.data` with SVG from the d2 CLI. This is trusted input from a local binary, but be aware of this if the trust model changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,12 @@
 # Changelog
+
+## Unreleased
+
+### Added
+
+- **Drag-to-pan**: Click and drag to pan the diagram in the preview window. Pan position is preserved across zoom changes and webview state recovery.
+- **Auxiliary window support**: Preview now survives being moved to an auxiliary window via "Move Editor Group into New Window". The extension caches the last rendered SVG and re-sends it when the webview regains visibility. The webview also persists its own state via `vscode.getState()`/`setState()` as a secondary recovery path.
+
+### Fixed
+
+- Clicking on a non-link area in the preview no longer throws an error (added null guard on `closest("a[href]")`).

--- a/pages/previewPage.html
+++ b/pages/previewPage.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <title>Diagram</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -78,6 +78,12 @@
         top: 10px;
         left: 0px;
         right: 0px;
+        cursor: grab;
+      }
+
+      #previewWrapper.dragging {
+        cursor: grabbing;
+        user-select: none;
       }
 
       #progressBar {
@@ -138,6 +144,12 @@
       var busyIndicator;
       var toast, toastMsg, toastList;
       var fitMode = true;
+      var panX = 0;
+      var panY = 0;
+      var isDragging = false;
+      var wasDragged = false;
+      var dragStartX = 0;
+      var dragStartY = 0;
       const vscode = acquireVsCodeApi();
 
       function init() {
@@ -165,6 +177,8 @@
         setZoomLevel(zoomLevel);
       }
       function zoomFit() {
+        panX = 0;
+        panY = 0;
         var widthPct = visualViewport.width / wrapper.clientWidth;
         var heightPct = (visualViewport.height - 45) / wrapper.clientHeight;
 
@@ -177,8 +191,11 @@
 
         fitMode = true;
       }
+      function applyTransform(zl) {
+        wrapper.style.transform = `translate(${panX}px, ${panY}px) scale(${zl / 100},${zl / 100})`;
+      }
       function setZoomLevel(zl) {
-        wrapper.style.transform = `scale(${zl / 100},${zl / 100})`;
+        applyTransform(zl);
         setZoomText(true);
 
         zoomSlider.value = zl;
@@ -202,8 +219,53 @@
         vscode.postMessage({ command: "refreshPage" });
       }
 
+      function onMouseDown(e) {
+        if (e.button !== 0) return;
+        isDragging = true;
+        wasDragged = false;
+        dragStartX = e.clientX - panX;
+        dragStartY = e.clientY - panY;
+        wrapper.classList.add("dragging");
+      }
+      function onMouseMove(e) {
+        if (!isDragging) return;
+        panX = e.clientX - dragStartX;
+        panY = e.clientY - dragStartY;
+        wasDragged = true;
+        applyTransform(zoomLevel);
+      }
+      function onMouseUp() {
+        if (!isDragging) return;
+        isDragging = false;
+        wrapper.classList.remove("dragging");
+      }
+
       window.addEventListener("DOMContentLoaded", () => {
         init();
+
+        wrapper.addEventListener("mousedown", onMouseDown);
+        window.addEventListener("mousemove", onMouseMove);
+        window.addEventListener("mouseup", onMouseUp);
+        window.addEventListener("mouseleave", onMouseUp);
+
+        // Restore state after webview iframe recreation (e.g. move to auxiliary window)
+        var previousState = vscode.getState();
+        if (previousState && previousState.svg) {
+          wrapper.innerHTML = previousState.svg;
+          if (typeof previousState.panX === "number") {
+            panX = previousState.panX;
+            panY = previousState.panY;
+          }
+          if (previousState.fitMode) {
+            zoomFit();
+          } else if (previousState.zoomLevel) {
+            setZoomLevel(previousState.zoomLevel);
+          }
+          toast.style.opacity = 0.0;
+        } else {
+          // No saved state — ask the extension to re-render
+          refreshPage();
+        }
       });
 
       window.addEventListener(
@@ -218,7 +280,7 @@
             }
           }
         },
-        { passive: false }
+        { passive: false },
       );
 
       window.addEventListener("message", (event) => {
@@ -233,6 +295,13 @@
             } else {
               setZoomLevel(zoomLevel);
             }
+            vscode.setState({
+              svg: message.data,
+              zoomLevel: zoomLevel,
+              fitMode: fitMode,
+              panX: panX,
+              panY: panY,
+            });
             window.postMessage({ command: "hideBusy" });
             break;
           case "showBusy":
@@ -263,13 +332,19 @@
       window.addEventListener(
         "click",
         (event) => {
+          if (wasDragged) {
+            wasDragged = false;
+            event.preventDefault();
+            return;
+          }
           const link = event.target.closest("a[href]");
+          if (!link) return;
           vscode.postMessage({
             command: "clickOnTag_A",
             link: link.href.baseVal || link.href,
           });
         },
-        false
+        false,
       );
     </script>
   </head>

--- a/pages/previewPage.html
+++ b/pages/previewPage.html
@@ -232,12 +232,22 @@
         panX = e.clientX - dragStartX;
         panY = e.clientY - dragStartY;
         wasDragged = true;
+        fitMode = false;
         applyTransform(zoomLevel);
       }
       function onMouseUp() {
         if (!isDragging) return;
         isDragging = false;
         wrapper.classList.remove("dragging");
+        if (wasDragged) {
+          vscode.setState({
+            svg: wrapper.innerHTML,
+            zoomLevel: zoomLevel,
+            fitMode: fitMode,
+            panX: panX,
+            panY: panY,
+          });
+        }
       }
 
       window.addEventListener("DOMContentLoaded", () => {

--- a/src/browserWindow.ts
+++ b/src/browserWindow.ts
@@ -13,6 +13,7 @@ export class BrowserWindow {
   webViewPanel: WebviewPanel;
   webView: Webview;
   trackerObject?: D2P;
+  private lastSvg: string = "";
 
   constructor(trkObj: D2P) {
     this.trackerObject = trkObj;
@@ -35,7 +36,7 @@ export class BrowserWindow {
         enableScripts: true,
         retainContextWhenHidden: true,
         localResourceRoots: [Uri.file(path.join(extContext.extensionPath, "pages"))],
-      }
+      },
     );
     this.webView = this.webViewPanel.webview;
 
@@ -49,6 +50,20 @@ export class BrowserWindow {
         this.trackerObject.outputDoc = undefined;
       }
     });
+
+    this.webViewPanel.onDidChangeViewState(
+      (e) => {
+        if (e.webviewPanel.visible) {
+          if (this.lastSvg) {
+            this.setSvg(this.lastSvg);
+          } else if (this.trackerObject?.inputDoc) {
+            previewGenerator.generate(this.trackerObject.inputDoc, false);
+          }
+        }
+      },
+      this,
+      extContext.subscriptions,
+    );
 
     const isRelative = (p: string) => !/^([a-z]+:)?[\\/]/i.test(p);
 
@@ -84,13 +99,13 @@ export class BrowserWindow {
                 } else {
                   util.openWithDefaultApp(filepath);
                 }
-              }
+              },
             );
           }
         }
       },
       this,
-      extContext.subscriptions
+      extContext.subscriptions,
     );
   }
 
@@ -99,6 +114,7 @@ export class BrowserWindow {
   }
 
   setSvg(svg: string): void {
+    this.lastSvg = svg;
     this.webView.postMessage({ command: "render", data: svg });
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -156,7 +156,7 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@eslint/js@9.17.0", "@eslint/js@^9.17.0":
+"@eslint/js@^9.17.0", "@eslint/js@9.17.0":
   version "9.17.0"
   resolved "https://registry.npmjs.org/@eslint/js/-/js-9.17.0.tgz"
   integrity sha512-Sxc4hqcs1kTu0iID3kcZDW3JHq2a77HO9P8CP6YEA/FpH3Ll8UXE2r/86Rz9YJLKme39S9vU5OWNjC6Xl0Cr3w==
@@ -280,7 +280,7 @@
     "@nodelib/fs.stat" "2.0.5"
     run-parallel "^1.1.9"
 
-"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
+"@nodelib/fs.stat@^2.0.2", "@nodelib/fs.stat@2.0.5":
   version "2.0.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz"
   integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
@@ -415,7 +415,7 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@8.18.0", "@typescript-eslint/eslint-plugin@^8.18.0":
+"@typescript-eslint/eslint-plugin@^8.18.0", "@typescript-eslint/eslint-plugin@8.18.0":
   version "8.18.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.18.0.tgz"
   integrity sha512-NR2yS7qUqCL7AIxdJUQf2MKKNDVNaig/dEB0GBLU7D+ZdHgK1NoH/3wsgO3OnPVipn51tG3MAwaODEGil70WEw==
@@ -430,7 +430,7 @@
     natural-compare "^1.4.0"
     ts-api-utils "^1.3.0"
 
-"@typescript-eslint/parser@8.18.0", "@typescript-eslint/parser@^8.18.0":
+"@typescript-eslint/parser@^8.0.0 || ^8.0.0-alpha.0", "@typescript-eslint/parser@^8.18.0", "@typescript-eslint/parser@8.18.0":
   version "8.18.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.18.0.tgz"
   integrity sha512-hgUZ3kTEpVzKaK3uNibExUYm6SKKOmTU2BOxBSvOYwtJEPdVQ70kZJpPjstlnhCHcuc2WGfSbpKlb/69ttyN5Q==
@@ -507,46 +507,6 @@
     ora "^7.0.1"
     semver "^7.6.2"
 
-"@vscode/vsce-sign-alpine-arm64@2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@vscode/vsce-sign-alpine-arm64/-/vsce-sign-alpine-arm64-2.0.2.tgz#4accc485e55aa6ff04b195b47f722ead57daa58e"
-  integrity sha512-E80YvqhtZCLUv3YAf9+tIbbqoinWLCO/B3j03yQPbjT3ZIHCliKZlsy1peNc4XNZ5uIb87Jn0HWx/ZbPXviuAQ==
-
-"@vscode/vsce-sign-alpine-x64@2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@vscode/vsce-sign-alpine-x64/-/vsce-sign-alpine-x64-2.0.2.tgz#4a4b7b505b4cc0f58596394897c49a0bce0e540c"
-  integrity sha512-n1WC15MSMvTaeJ5KjWCzo0nzjydwxLyoHiMJHu1Ov0VWTZiddasmOQHekA47tFRycnt4FsQrlkSCTdgHppn6bw==
-
-"@vscode/vsce-sign-darwin-arm64@2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@vscode/vsce-sign-darwin-arm64/-/vsce-sign-darwin-arm64-2.0.2.tgz#10aa69feb7f81a3dc68c242038ca03eaff19c12e"
-  integrity sha512-rz8F4pMcxPj8fjKAJIfkUT8ycG9CjIp888VY/6pq6cuI2qEzQ0+b5p3xb74CJnBbSC0p2eRVoe+WgNCAxCLtzQ==
-
-"@vscode/vsce-sign-darwin-x64@2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@vscode/vsce-sign-darwin-x64/-/vsce-sign-darwin-x64-2.0.2.tgz#3315528f3ea1007a648b3320bff36a33a9e07aa5"
-  integrity sha512-MCjPrQ5MY/QVoZ6n0D92jcRb7eYvxAujG/AH2yM6lI0BspvJQxp0o9s5oiAM9r32r9tkLpiy5s2icsbwefAQIw==
-
-"@vscode/vsce-sign-linux-arm64@2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@vscode/vsce-sign-linux-arm64/-/vsce-sign-linux-arm64-2.0.2.tgz#ce5c5cfc99e3454b4fb770405812b46bd6dca870"
-  integrity sha512-Ybeu7cA6+/koxszsORXX0OJk9N0GgfHq70Wqi4vv2iJCZvBrOWwcIrxKjvFtwyDgdeQzgPheH5nhLVl5eQy7WA==
-
-"@vscode/vsce-sign-linux-arm@2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@vscode/vsce-sign-linux-arm/-/vsce-sign-linux-arm-2.0.2.tgz#4142fda83e7130b31aedd8aa81e4daa6334323c2"
-  integrity sha512-Fkb5jpbfhZKVw3xwR6t7WYfwKZktVGNXdg1m08uEx1anO0oUPUkoQRsNm4QniL3hmfw0ijg00YA6TrxCRkPVOQ==
-
-"@vscode/vsce-sign-linux-x64@2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@vscode/vsce-sign-linux-x64/-/vsce-sign-linux-x64-2.0.2.tgz#59ab93f322efb3cf49166d4e2e812789c3117428"
-  integrity sha512-NsPPFVtLaTlVJKOiTnO8Cl78LZNWy0Q8iAg+LlBiCDEgC12Gt4WXOSs2pmcIjDYzj2kY4NwdeN1mBTaujYZaPg==
-
-"@vscode/vsce-sign-win32-arm64@2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@vscode/vsce-sign-win32-arm64/-/vsce-sign-win32-arm64-2.0.2.tgz#d095704a14b0404c0b6f696e9889e9a51b31a86c"
-  integrity sha512-wPs848ymZ3Ny+Y1Qlyi7mcT6VSigG89FWQnp2qRYCyMhdJxOpA4lDwxzlpL8fG6xC8GjQjGDkwbkWUcCobvksQ==
-
 "@vscode/vsce-sign-win32-x64@2.0.2":
   version "2.0.2"
   resolved "https://registry.npmjs.org/@vscode/vsce-sign-win32-x64/-/vsce-sign-win32-x64-2.0.2.tgz"
@@ -599,7 +559,7 @@
   optionalDependencies:
     keytar "^7.7.0"
 
-"@webassemblyjs/ast@1.14.1", "@webassemblyjs/ast@^1.14.1":
+"@webassemblyjs/ast@^1.14.1", "@webassemblyjs/ast@1.14.1":
   version "1.14.1"
   resolved "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz"
   integrity sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==
@@ -700,7 +660,7 @@
     "@webassemblyjs/wasm-gen" "1.14.1"
     "@webassemblyjs/wasm-parser" "1.14.1"
 
-"@webassemblyjs/wasm-parser@1.14.1", "@webassemblyjs/wasm-parser@^1.14.1":
+"@webassemblyjs/wasm-parser@^1.14.1", "@webassemblyjs/wasm-parser@1.14.1":
   version "1.14.1"
   resolved "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz"
   integrity sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==
@@ -750,7 +710,7 @@ acorn-jsx@^5.3.2:
   resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-acorn@^8.14.0, acorn@^8.8.2:
+"acorn@^6.0.0 || ^7.0.0 || ^8.0.0", acorn@^8.14.0, acorn@^8.8.2:
   version "8.14.0"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz"
   integrity sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==
@@ -779,7 +739,7 @@ ajv-keywords@^5.1.0:
   dependencies:
     fast-deep-equal "^3.1.3"
 
-ajv@^6.12.4, ajv@^6.12.5:
+ajv@^6.12.4, ajv@^6.12.5, ajv@^6.9.1:
   version "6.12.6"
   resolved "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -789,7 +749,17 @@ ajv@^6.12.4, ajv@^6.12.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.0.0, ajv@^8.9.0:
+ajv@^8.0.0:
+  version "8.17.1"
+  resolved "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz"
+  integrity sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    fast-uri "^3.0.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+
+ajv@^8.8.2, ajv@^8.9.0:
   version "8.17.1"
   resolved "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz"
   integrity sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==
@@ -826,7 +796,14 @@ ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
-ansi-styles@^4.0.0, ansi-styles@^4.1.0:
+ansi-styles@^4.0.0:
+  version "4.3.0"
+  resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz"
+  integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
+  dependencies:
+    color-convert "^2.0.1"
+
+ansi-styles@^4.1.0:
   version "4.3.0"
   resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz"
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
@@ -936,7 +913,7 @@ browser-stdout@^1.3.1:
   resolved "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz"
   integrity sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==
 
-browserslist@^4.24.0:
+browserslist@^4.24.0, "browserslist@>= 4.21.0":
   version "4.24.3"
   resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.24.3.tgz"
   integrity sha512-1CPmv8iobE2fyRMV97dAcMVegvvWKxmq94hkLiAkUGwKVTyDLw33K+ZxiFrREKmmps4rIw6grcCFCnTMSZ/YiA==
@@ -1027,7 +1004,15 @@ chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4.0.0, chalk@^4.1.0:
+chalk@^4.0.0:
+  version "4.1.2"
+  resolved "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
+chalk@^4.1.0:
   version "4.1.2"
   resolved "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -1153,15 +1138,15 @@ color-convert@^2.0.1:
   dependencies:
     color-name "~1.1.4"
 
-color-name@1.1.3:
-  version "1.1.3"
-  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
-  integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
-
 color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+color-name@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
+  integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
 
 colorette@^2.0.14:
   version "2.0.20"
@@ -1225,7 +1210,7 @@ css-what@^6.1.0:
   resolved "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz"
   integrity sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==
 
-debug@4, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.5:
+debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.5, debug@4:
   version "4.4.0"
   resolved "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz"
   integrity sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==
@@ -1460,14 +1445,6 @@ eslint-rule-docs@^1.1.235:
   resolved "https://registry.npmjs.org/eslint-rule-docs/-/eslint-rule-docs-1.1.235.tgz"
   integrity sha512-+TQ+x4JdTnDoFEXXb3fDvfGOwnyNV7duH8fXWTPD1ieaBmB8omj7Gw/pMBBu4uI2uJCCU8APDaQJzWuXnTsH4A==
 
-eslint-scope@5.1.1:
-  version "5.1.1"
-  resolved "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz"
-  integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
-  dependencies:
-    esrecurse "^4.3.0"
-    estraverse "^4.1.1"
-
 eslint-scope@^8.2.0:
   version "8.2.0"
   resolved "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.2.0.tgz"
@@ -1475,6 +1452,14 @@ eslint-scope@^8.2.0:
   dependencies:
     esrecurse "^4.3.0"
     estraverse "^5.2.0"
+
+eslint-scope@5.1.1:
+  version "5.1.1"
+  resolved "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz"
+  integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
+  dependencies:
+    esrecurse "^4.3.0"
+    estraverse "^4.1.1"
 
 eslint-utils@^3.0.0:
   version "3.0.0"
@@ -1509,7 +1494,7 @@ eslint-webpack-plugin@^4.2.0:
     normalize-path "^3.0.0"
     schema-utils "^4.2.0"
 
-eslint@^9.17.0:
+"eslint@^6.0.0 || ^7.0.0 || >=8.0.0", "eslint@^8.0.0 || ^9.0.0", "eslint@^8.57.0 || ^9.0.0", eslint@^9.17.0, eslint@>=5, eslint@>=7.0.0:
   version "9.17.0"
   resolved "https://registry.npmjs.org/eslint/-/eslint-9.17.0.tgz"
   integrity sha512-evtlNcpJg+cZLcnVKwsai8fExnqjGPicK7gnUtlNuzu+Fv9bI0aLpND5T44VLQtoMEnI57LoXO9XAkIXwohKrA==
@@ -1722,11 +1707,6 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
-fsevents@~2.3.2:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
-  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
-
 function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz"
@@ -1763,7 +1743,7 @@ github-from-package@0.0.0:
   resolved "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz"
   integrity sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==
 
-glob-parent@^5.1.2, glob-parent@~5.1.2:
+glob-parent@^5.1.2:
   version "5.1.2"
   resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -1776,6 +1756,13 @@ glob-parent@^6.0.2:
   integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
   dependencies:
     is-glob "^4.0.3"
+
+glob-parent@~5.1.2:
+  version "5.1.2"
+  resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz"
+  integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
+  dependencies:
+    is-glob "^4.0.1"
 
 glob-to-regexp@^0.4.1:
   version "0.4.1"
@@ -1909,7 +1896,7 @@ https-proxy-agent@^7.0.0, https-proxy-agent@^7.0.5:
     agent-base "^7.1.2"
     debug "4"
 
-iconv-lite@0.6.3, iconv-lite@^0.6.3:
+iconv-lite@^0.6.3, iconv-lite@0.6.3:
   version "0.6.3"
   resolved "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz"
   integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
@@ -1960,7 +1947,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3:
+inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3, inherits@2:
   version "2.0.4"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -2911,7 +2898,12 @@ safe-buffer@^5.0.1, safe-buffer@^5.1.0:
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
-safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@~5.1.0:
+  version "5.1.2"
+  resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz"
+  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
+
+safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
@@ -3092,6 +3084,13 @@ stoppable@^1.1.0:
   resolved "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz"
   integrity sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==
 
+string_decoder@^1.1.1, string_decoder@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz"
+  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
+  dependencies:
+    safe-buffer "~5.1.0"
+
 "string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
@@ -3110,7 +3109,16 @@ string-width@^4.1.0, string-width@^4.2.0:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
 
-string-width@^5.0.1, string-width@^5.1.2:
+string-width@^5.0.1:
+  version "5.1.2"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz"
+  integrity sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==
+  dependencies:
+    eastasianwidth "^0.2.0"
+    emoji-regex "^9.2.2"
+    strip-ansi "^7.0.1"
+
+string-width@^5.1.2:
   version "5.1.2"
   resolved "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz"
   integrity sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==
@@ -3136,13 +3144,6 @@ string-width@^7.0.0:
     emoji-regex "^10.3.0"
     get-east-asian-width "^1.0.0"
     strip-ansi "^7.1.0"
-
-string_decoder@^1.1.1, string_decoder@~1.1.1:
-  version "1.1.1"
-  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz"
-  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
-  dependencies:
-    safe-buffer "~5.1.0"
 
 "strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
@@ -3182,14 +3183,28 @@ supports-color@^5.3.0:
   dependencies:
     has-flag "^3.0.0"
 
-supports-color@^7.0.0, supports-color@^7.1.0:
+supports-color@^7.0.0:
   version "7.2.0"
   resolved "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
   dependencies:
     has-flag "^4.0.0"
 
-supports-color@^8.0.0, supports-color@^8.1.1:
+supports-color@^7.1.0:
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz"
+  integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
+  dependencies:
+    has-flag "^4.0.0"
+
+supports-color@^8.0.0:
+  version "8.1.1"
+  resolved "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz"
+  integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
+  dependencies:
+    has-flag "^4.0.0"
+
+supports-color@^8.1.1:
   version "8.1.1"
   resolved "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz"
   integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
@@ -3326,7 +3341,7 @@ typescript-eslint@^8.18.0:
     "@typescript-eslint/parser" "8.18.0"
     "@typescript-eslint/utils" "8.18.0"
 
-typescript@^5.6.3:
+typescript@*, typescript@^5.6.3, typescript@>=4.2.0, "typescript@>=4.8.4 <5.8.0":
   version "5.7.2"
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz"
   integrity sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==
@@ -3389,7 +3404,7 @@ watchpack@^2.4.1:
     glob-to-regexp "^0.4.1"
     graceful-fs "^4.1.2"
 
-webpack-cli@^5.1.4:
+webpack-cli@^5.1.4, webpack-cli@5.x.x:
   version "5.1.4"
   resolved "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.4.tgz"
   integrity sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==
@@ -3422,7 +3437,7 @@ webpack-sources@^3.2.3:
   resolved "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz"
   integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
 
-webpack@^5.96.1:
+webpack@^5.0.0, webpack@^5.1.0, webpack@^5.96.1, webpack@5.x.x:
   version "5.97.1"
   resolved "https://registry.npmjs.org/webpack/-/webpack-5.97.1.tgz"
   integrity sha512-EksG6gFY3L1eFMROS/7Wzgrii5mBAFe4rIr3r2BTfo7bcc+DWwFZ4OJ/miOuHJO/A85HwyI4eQ0F6IKXesO7Fg==


### PR DESCRIPTION
- Fixed issue where preview was moved to a new VS Code window.

Issue summary: When the D2 preview webview is moved to an auxiliary window ("Move Editor Group into New Window"), the iframe is physically destroyed and recreated in the new window's DOM. This causes the webview's JavaScript context to reset — losing the rendered SVG, zoom state, and all dynamic content. The extension host never detects this happened (no onDidChangeViewState listener), so no re-render is triggered. The user sees a blank preview with "Loading..." toast.

- Added Click-Drag to Pan diagram feature

- Introduced AGENTS.md to provide comprehensive documentation for the D2-vscode extension.
- Included project overview, architecture, directory structure, data flow, extension specifics, build and development instructions, and common pitfalls.
- Documented key dependencies and module responsibilities to aid developers and contributors.